### PR TITLE
fix(grabber-kms): performance and stability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "clap 4.6.0",
  "clap-verbosity-flag",
  "color-eyre",
+ "crc32fast",
  "crossbeam-channel",
  "drm",
  "gbm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "hyperion"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ambassador",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperion"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Alixinne <alixinne@pm.me>"]
 edition = "2018"
 default-run = "hyperiond"

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       system:
       let
         # TODO: Update this on new releases
-        version = "0.3.2";
+        version = "0.3.3";
 
         pkgs = nixpkgs.legacyPackages.${system};
         raspberryPiZeroTarget = "arm-unknown-linux-gnueabihf";

--- a/hyperion-grabber-kms/Cargo.toml
+++ b/hyperion-grabber-kms/Cargo.toml
@@ -14,7 +14,7 @@ crossbeam-channel = "0.5.15"
 drm = "0.15.0"
 gbm = { version = "0.18.0", default-features = false }
 glutin = { version = "0.32.3", default-features = false, features = ["egl"] }
-hyperion = { version = "0.3.2", path = "..", default-features = false }
+hyperion = { version = "0.3.3", path = "..", default-features = false }
 png = "0.18.1"
 prost = "0.14.3"
 signal-hook = "0.4.4"

--- a/hyperion-grabber-kms/Cargo.toml
+++ b/hyperion-grabber-kms/Cargo.toml
@@ -9,6 +9,7 @@ bytes = "1.11.1"
 clap = { version = "4.6.0", features = ["env", "derive"] }
 clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 color-eyre = "0.6.5"
+crc32fast = "1.5.0"
 crossbeam-channel = "0.5.15"
 drm = "0.15.0"
 gbm = { version = "0.18.0", default-features = false }

--- a/hyperion-grabber-kms/src/capture.rs
+++ b/hyperion-grabber-kms/src/capture.rs
@@ -59,7 +59,6 @@ pub struct KmsCapture {
     renderbuffer: GLuint,
     width: u32,
     height: u32,
-    buffer: BytesMut,
 
     // GL state is bound to the current thread, it can't be sent across threads
     _unsend: PhantomData<*const ()>,
@@ -80,11 +79,17 @@ impl Drop for KmsCapture {
 impl KmsCapture {
     pub fn next_frame(
         &mut self,
+        buffer: &mut BytesMut,
         tone_mapping_offset: f32,
         tone_mapping_scaling: f32,
-    ) -> (BytesMut, (u32, u32)) {
+    ) -> (u32, u32) {
         self.renderer
             .draw(tone_mapping_offset, tone_mapping_scaling);
+
+        // Clear buffer
+        let buf_len = (self.width * self.height * 4) as _;
+        buffer.clear();
+        buffer.reserve(buf_len);
 
         unsafe {
             // Wait for the previous commands to finish before reading from the framebuffer.
@@ -98,13 +103,13 @@ impl KmsCapture {
                 self.height as _,
                 gl::RGBA,
                 gl::UNSIGNED_BYTE,
-                self.buffer.as_mut_ptr() as *mut _,
+                buffer.as_mut_ptr() as *mut _,
             );
 
-            self.buffer.set_len((self.width * self.height * 4) as _);
+            buffer.set_len(buf_len);
         }
 
-        (self.buffer.clone(), (self.width, self.height))
+        (self.width, self.height)
     }
 }
 
@@ -324,7 +329,6 @@ pub fn init(card_path: &Path, image_width: u32) -> color_eyre::eyre::Result<KmsC
         renderbuffer,
         width,
         height,
-        buffer: BytesMut::with_capacity((width * height * 4) as _),
         _unsend: Default::default(),
     })
 }

--- a/hyperion-grabber-kms/src/capture.rs
+++ b/hyperion-grabber-kms/src/capture.rs
@@ -54,6 +54,8 @@ impl Card {
 }
 
 pub struct KmsCapture {
+    card: Card,
+    display: Display,
     renderer: graphics::Renderer,
     framebuffer: GLuint,
     renderbuffer: GLuint,
@@ -110,6 +112,174 @@ impl KmsCapture {
         }
 
         (self.width, self.height)
+    }
+
+    pub fn attach_plane(&mut self) -> color_eyre::eyre::Result<()> {
+        let (_handle, _info, fb) = self
+            .card
+            .plane_handles()?
+            .into_iter()
+            .find_map(|handle| {
+                let info = self.card.get_plane(handle).ok()?;
+                if !(info.crtc().is_some() && info.framebuffer().is_some()) {
+                    return None;
+                }
+
+                let fb = self
+                    .card
+                    .get_planar_framebuffer(info.framebuffer().unwrap())
+                    .ok()?;
+                if !(fb.size().0 >= 640 && fb.size().1 >= 480) {
+                    return None;
+                }
+
+                debug!("Plane: {handle:?}");
+                debug!("\tCRTC: {:?}", info.crtc());
+                debug!("\tFramebuffer: {:?}", info.framebuffer());
+                debug!("\tFormats: {:?}", info.formats());
+
+                debug!("Framebuffer: {handle:?}");
+                debug!("\tSize: {:?}", fb.size());
+                debug!("\tFlags: {:?}", fb.flags());
+                debug!("\tPixel format: {:?}", fb.pixel_format());
+                debug!("\tModifiers: {:?}", fb.modifier());
+
+                debug!("\tBuffers: {:?}", fb.buffers());
+                debug!("\tPitches: {:?}", fb.pitches());
+                debug!("\tOffsets: {:?}", fb.offsets());
+
+                Some((handle, info, fb))
+            })
+            .unwrap();
+
+        let bpo = fb
+            .buffers()
+            .iter()
+            .zip(fb.pitches())
+            .zip(fb.offsets())
+            .filter_map(|((f, p), o)| {
+                f.map(|x| (self.card.buffer_to_prime_fd(x, 0).unwrap(), p, o))
+            })
+            .collect::<Vec<_>>();
+
+        let width = self.width;
+        let height = (self.width * fb.size().1) / fb.size().0;
+
+        self.width = width;
+        self.height = height;
+        self.renderer.resize(width as _, height as _);
+
+        // Create a framebuffer for offscreen rendering since we do not have a window.
+        unsafe {
+            if self.framebuffer == 0 {
+                self.renderer.GenFramebuffers(1, &mut self.framebuffer);
+            }
+            if self.renderbuffer == 0 {
+                self.renderer.GenRenderbuffers(1, &mut self.renderbuffer);
+            }
+            self.renderer
+                .BindFramebuffer(gl::FRAMEBUFFER, self.framebuffer);
+            self.renderer
+                .BindRenderbuffer(gl::RENDERBUFFER, self.renderbuffer);
+            self.renderer
+                .RenderbufferStorage(gl::RENDERBUFFER, gl::RGBA8, width as _, height as _);
+            self.renderer.FramebufferRenderbuffer(
+                gl::FRAMEBUFFER,
+                gl::COLOR_ATTACHMENT0,
+                gl::RENDERBUFFER,
+                self.renderbuffer,
+            );
+        }
+
+        unsafe {
+            let display_ptr = match self.display.raw_display() {
+                glutin::display::RawDisplay::Egl(ptr) => ptr,
+            };
+
+            let modifier: u64 = fb.modifier().unwrap().into();
+
+            let attribs = if bpo.len() > 1 {
+                [
+                    egl::WIDTH as isize,
+                    fb.size().0 as _,
+                    egl::HEIGHT as _,
+                    fb.size().1 as _,
+                    egl::LINUX_DRM_FOURCC_EXT as isize,
+                    fb.pixel_format() as _,
+                    // Plane 0
+                    egl::DMA_BUF_PLANE0_FD_EXT as isize,
+                    bpo[0].0.as_raw_fd() as isize,
+                    egl::DMA_BUF_PLANE0_PITCH_EXT as isize,
+                    bpo[0].1 as _,
+                    egl::DMA_BUF_PLANE0_OFFSET_EXT as isize,
+                    bpo[0].2 as _,
+                    egl::DMA_BUF_PLANE0_MODIFIER_LO_EXT as isize,
+                    (modifier & 0xFFFF_FFFF) as isize,
+                    egl::DMA_BUF_PLANE0_MODIFIER_HI_EXT as isize,
+                    (modifier >> 32) as isize,
+                    // Plane 1
+                    egl::DMA_BUF_PLANE1_FD_EXT as isize,
+                    bpo[1].0.as_raw_fd() as isize,
+                    egl::DMA_BUF_PLANE1_PITCH_EXT as isize,
+                    bpo[1].1 as _,
+                    egl::DMA_BUF_PLANE1_OFFSET_EXT as isize,
+                    bpo[1].2 as _,
+                    egl::DMA_BUF_PLANE1_MODIFIER_LO_EXT as isize,
+                    (modifier & 0xFFFF_FFFF) as isize,
+                    egl::DMA_BUF_PLANE1_MODIFIER_HI_EXT as isize,
+                    (modifier >> 32) as isize,
+                    // Plane 2
+                    egl::DMA_BUF_PLANE2_FD_EXT as isize,
+                    bpo[2].0.as_raw_fd() as isize,
+                    egl::DMA_BUF_PLANE2_PITCH_EXT as isize,
+                    bpo[2].1 as _,
+                    egl::DMA_BUF_PLANE2_OFFSET_EXT as isize,
+                    bpo[2].2 as _,
+                    egl::DMA_BUF_PLANE2_MODIFIER_LO_EXT as isize,
+                    (modifier & 0xFFFF_FFFF) as isize,
+                    egl::DMA_BUF_PLANE2_MODIFIER_HI_EXT as isize,
+                    (modifier >> 32) as isize,
+                    egl::NONE as isize,
+                ]
+                .to_vec()
+            } else {
+                [
+                    egl::WIDTH as isize,
+                    fb.size().0 as _,
+                    egl::HEIGHT as _,
+                    fb.size().1 as _,
+                    egl::LINUX_DRM_FOURCC_EXT as isize,
+                    fb.pixel_format() as _,
+                    // Plane 0
+                    egl::DMA_BUF_PLANE0_FD_EXT as isize,
+                    bpo[0].0.as_raw_fd() as isize,
+                    egl::DMA_BUF_PLANE0_PITCH_EXT as isize,
+                    bpo[0].1 as _,
+                    egl::DMA_BUF_PLANE0_OFFSET_EXT as isize,
+                    bpo[0].2 as _,
+                    egl::DMA_BUF_PLANE0_MODIFIER_LO_EXT as isize,
+                    (modifier & 0xFFFF_FFFF) as isize,
+                    egl::DMA_BUF_PLANE0_MODIFIER_HI_EXT as isize,
+                    (modifier >> 32) as isize,
+                    egl::NONE as isize,
+                ]
+                .to_vec()
+            };
+
+            let image = self.renderer.egl().CreateImage(
+                display_ptr,
+                null_mut(),
+                egl::LINUX_DMA_BUF_EXT,
+                null_mut(),
+                attribs.as_ptr(),
+            );
+
+            self.renderer.prepare_texture(image);
+
+            self.renderer.egl().DestroyImage(display_ptr, image);
+        }
+
+        Ok(())
     }
 }
 
@@ -169,168 +339,25 @@ pub fn init(card_path: &Path, image_width: u32) -> color_eyre::eyre::Result<KmsC
     // Make the context current for rendering
     let _context = not_current.make_current_surfaceless().unwrap();
 
+    // Initialize renderer
     let renderer = graphics::Renderer::new(&display);
-    let (_handle, _info, fb) = card
-        .plane_handles()?
-        .into_iter()
-        .find_map(|handle| {
-            let info = card.get_plane(handle).ok()?;
-            if !(info.crtc().is_some() && info.framebuffer().is_some()) {
-                return None;
-            }
 
-            let fb = card
-                .get_planar_framebuffer(info.framebuffer().unwrap())
-                .ok()?;
-            if !(fb.size().0 >= 640 && fb.size().1 >= 480) {
-                return None;
-            }
-
-            debug!("Plane: {handle:?}");
-            debug!("\tCRTC: {:?}", info.crtc());
-            debug!("\tFramebuffer: {:?}", info.framebuffer());
-            debug!("\tFormats: {:?}", info.formats());
-
-            debug!("Framebuffer: {handle:?}");
-            debug!("\tSize: {:?}", fb.size());
-            debug!("\tFlags: {:?}", fb.flags());
-            debug!("\tPixel format: {:?}", fb.pixel_format());
-            debug!("\tModifiers: {:?}", fb.modifier());
-
-            debug!("\tBuffers: {:?}", fb.buffers());
-            debug!("\tPitches: {:?}", fb.pitches());
-            debug!("\tOffsets: {:?}", fb.offsets());
-
-            Some((handle, info, fb))
-        })
-        .unwrap();
-
-    let bpo = fb
-        .buffers()
-        .iter()
-        .zip(fb.pitches())
-        .zip(fb.offsets())
-        .filter_map(|((f, p), o)| f.map(|x| (card.buffer_to_prime_fd(x, 0).unwrap(), p, o)))
-        .collect::<Vec<_>>();
-
-    let width = image_width;
-    let height = (image_width * fb.size().1) / fb.size().0;
-
-    renderer.resize(width as _, height as _);
-
-    // Create a framebuffer for offscreen rendering since we do not have a window.
-    let mut framebuffer = 0;
-    let mut renderbuffer = 0;
-    unsafe {
-        renderer.GenFramebuffers(1, &mut framebuffer);
-        renderer.GenRenderbuffers(1, &mut renderbuffer);
-        renderer.BindFramebuffer(gl::FRAMEBUFFER, framebuffer);
-        renderer.BindRenderbuffer(gl::RENDERBUFFER, renderbuffer);
-        renderer.RenderbufferStorage(gl::RENDERBUFFER, gl::RGBA8, width as _, height as _);
-        renderer.FramebufferRenderbuffer(
-            gl::FRAMEBUFFER,
-            gl::COLOR_ATTACHMENT0,
-            gl::RENDERBUFFER,
-            renderbuffer,
-        );
-    }
-
-    unsafe {
-        let display_ptr = match display.raw_display() {
-            glutin::display::RawDisplay::Egl(ptr) => ptr,
-        };
-
-        let modifier: u64 = fb.modifier().unwrap().into();
-
-        let attribs = if bpo.len() > 1 {
-            [
-                egl::WIDTH as isize,
-                fb.size().0 as _,
-                egl::HEIGHT as _,
-                fb.size().1 as _,
-                egl::LINUX_DRM_FOURCC_EXT as isize,
-                fb.pixel_format() as _,
-                // Plane 0
-                egl::DMA_BUF_PLANE0_FD_EXT as isize,
-                bpo[0].0.as_raw_fd() as isize,
-                egl::DMA_BUF_PLANE0_PITCH_EXT as isize,
-                bpo[0].1 as _,
-                egl::DMA_BUF_PLANE0_OFFSET_EXT as isize,
-                bpo[0].2 as _,
-                egl::DMA_BUF_PLANE0_MODIFIER_LO_EXT as isize,
-                (modifier & 0xFFFF_FFFF) as isize,
-                egl::DMA_BUF_PLANE0_MODIFIER_HI_EXT as isize,
-                (modifier >> 32) as isize,
-                // Plane 1
-                egl::DMA_BUF_PLANE1_FD_EXT as isize,
-                bpo[1].0.as_raw_fd() as isize,
-                egl::DMA_BUF_PLANE1_PITCH_EXT as isize,
-                bpo[1].1 as _,
-                egl::DMA_BUF_PLANE1_OFFSET_EXT as isize,
-                bpo[1].2 as _,
-                egl::DMA_BUF_PLANE1_MODIFIER_LO_EXT as isize,
-                (modifier & 0xFFFF_FFFF) as isize,
-                egl::DMA_BUF_PLANE1_MODIFIER_HI_EXT as isize,
-                (modifier >> 32) as isize,
-                // Plane 2
-                egl::DMA_BUF_PLANE2_FD_EXT as isize,
-                bpo[2].0.as_raw_fd() as isize,
-                egl::DMA_BUF_PLANE2_PITCH_EXT as isize,
-                bpo[2].1 as _,
-                egl::DMA_BUF_PLANE2_OFFSET_EXT as isize,
-                bpo[2].2 as _,
-                egl::DMA_BUF_PLANE2_MODIFIER_LO_EXT as isize,
-                (modifier & 0xFFFF_FFFF) as isize,
-                egl::DMA_BUF_PLANE2_MODIFIER_HI_EXT as isize,
-                (modifier >> 32) as isize,
-                egl::NONE as isize,
-            ]
-            .to_vec()
-        } else {
-            [
-                egl::WIDTH as isize,
-                fb.size().0 as _,
-                egl::HEIGHT as _,
-                fb.size().1 as _,
-                egl::LINUX_DRM_FOURCC_EXT as isize,
-                fb.pixel_format() as _,
-                // Plane 0
-                egl::DMA_BUF_PLANE0_FD_EXT as isize,
-                bpo[0].0.as_raw_fd() as isize,
-                egl::DMA_BUF_PLANE0_PITCH_EXT as isize,
-                bpo[0].1 as _,
-                egl::DMA_BUF_PLANE0_OFFSET_EXT as isize,
-                bpo[0].2 as _,
-                egl::DMA_BUF_PLANE0_MODIFIER_LO_EXT as isize,
-                (modifier & 0xFFFF_FFFF) as isize,
-                egl::DMA_BUF_PLANE0_MODIFIER_HI_EXT as isize,
-                (modifier >> 32) as isize,
-                egl::NONE as isize,
-            ]
-            .to_vec()
-        };
-
-        let image = renderer.egl().CreateImage(
-            display_ptr,
-            null_mut(),
-            egl::LINUX_DMA_BUF_EXT,
-            null_mut(),
-            attribs.as_ptr(),
-        );
-
-        renderer.prepare_texture(image);
-
-        renderer.egl().DestroyImage(display_ptr, image);
-    }
-
-    Ok(KmsCapture {
+    // Initialize capture state
+    let mut capture = KmsCapture {
+        card,
         renderer,
-        framebuffer,
-        renderbuffer,
-        width,
-        height,
+        display,
+        framebuffer: 0,
+        renderbuffer: 0,
+        width: image_width,
+        height: 0,
         _unsend: Default::default(),
-    })
+    };
+
+    // Attach current framebuffer once
+    capture.attach_plane()?;
+
+    Ok(capture)
 }
 
 fn config_template() -> ConfigTemplate {

--- a/hyperion-grabber-kms/src/main.rs
+++ b/hyperion-grabber-kms/src/main.rs
@@ -19,6 +19,7 @@ use hyperion::api::proto::message::ImageRequest;
 use hyperion::servers::proto::ProtoCodec;
 use tokio_util::codec::Encoder;
 use tracing::error;
+use tracing::info;
 
 mod capture;
 
@@ -150,6 +151,9 @@ fn main() -> color_eyre::eyre::Result<()> {
 
     // Frame capture loop
     let mut frame_buf = BytesMut::new();
+    // Still frame tracking
+    let mut last_crc = 0u32;
+    let mut start_still_frame = Instant::now();
     while !term.load(Ordering::Relaxed) {
         let start_frame = Instant::now();
         let next_frame = start_frame + Duration::from_micros(1_000_000 / opts.fps as u64);
@@ -172,10 +176,27 @@ fn main() -> color_eyre::eyre::Result<()> {
             next_frame,
         );
 
-        // Wait for next frame
+        // Compute crc32
+        let new_crc = crc32fast::hash(&frame_buf);
+        if last_crc != new_crc {
+            // The image has changed, update crc and reset timing
+            last_crc = new_crc;
+            start_still_frame = start_frame;
+        }
+
+        // Wait for next frame, or refresh buffer if we've had still frames for too long
         let now = Instant::now();
-        if next_frame > now {
-            sleep(next_frame - now);
+        if now - start_still_frame > Duration::from_secs(5) {
+            info!("Still image for more than 5 seconds, refreshing capture texture");
+
+            // Reset state, reattach current fb
+            capture.attach_plane()?;
+            last_crc = 0;
+            start_still_frame = now;
+        } else {
+            if next_frame > now {
+                sleep(next_frame - now);
+            }
         }
     }
 

--- a/hyperion-grabber-kms/src/main.rs
+++ b/hyperion-grabber-kms/src/main.rs
@@ -9,6 +9,8 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
 
+use bytes::Buf;
+use bytes::Bytes;
 use bytes::BytesMut;
 use clap::Parser;
 use hyperion::api::proto::message::ClearRequest;
@@ -55,7 +57,7 @@ struct Opts {
 }
 
 struct ImageMessage {
-    buffer: BytesMut,
+    buffer: Bytes,
     width: u32,
     height: u32,
 }
@@ -147,19 +149,23 @@ fn main() -> color_eyre::eyre::Result<()> {
     });
 
     // Frame capture loop
+    let mut frame_buf = BytesMut::new();
     while !term.load(Ordering::Relaxed) {
         let start_frame = Instant::now();
         let next_frame = start_frame + Duration::from_micros(1_000_000 / opts.fps as u64);
 
         // Capture frame
-        let (buffer, (width, height)) =
-            capture.next_frame(opts.tone_mapping_offset, opts.tone_mapping_scaling);
+        let (width, height) = capture.next_frame(
+            &mut frame_buf,
+            opts.tone_mapping_offset,
+            opts.tone_mapping_scaling,
+        );
 
         // Forward it to network loop, but if the network loop is busy just drop it and move on to
         // the next frame to avoid running late
         let _ = tx.send_deadline(
             ImageMessage {
-                buffer,
+                buffer: frame_buf.copy_to_bytes(frame_buf.len()),
                 width,
                 height,
             },

--- a/hyperion-grabber-kms/src/main.rs
+++ b/hyperion-grabber-kms/src/main.rs
@@ -135,10 +135,13 @@ fn main() -> color_eyre::eyre::Result<()> {
         let term = term.clone();
         let target_host = opts.target_host.clone();
         move || {
-            while let Err(error) =
-                network_loop(term.clone(), rx.clone(), target_host.clone(), opts.fps)
-            {
-                error!(%error, "Network loop failed, restarting");
+            while !term.load(Ordering::Relaxed) {
+                if let Err(error) =
+                    network_loop(term.clone(), rx.clone(), target_host.clone(), opts.fps)
+                {
+                    error!(%error, "Network loop failed, restarting in 5s");
+                    sleep(Duration::from_secs(5));
+                }
             }
         }
     });


### PR DESCRIPTION
- **fix(grabber-kms): add retry delay in network loop**
- **perf(grabber-kms): reduce number of copies when reading frames**
- **fix(grabber-kms): detect stale fb and restart capture when needed**
- **chore: bump version to v0.3.3**
